### PR TITLE
Update header to remove unnecessary `<base>` tag

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,6 @@
 
 		{{ partial "meta.html" . }}
 
-		<base href="{{ .Site.BaseURL }}" />
 		{{ if .Title }}<title>{{ .Title }} - SS14</title>{{ else }}<title>Space Station 14</title>{{ end }}
 		<link rel="canonical" href="{{ .Permalink }}" />
 		{{ range .AlternativeOutputFormats -}}


### PR DESCRIPTION
Not sure why this is here, but it's breaking anchor links (anchors are pointing to the root page of the site rather than the page they're on.)

See [`<base>` at MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base) for more information on how this tag works.